### PR TITLE
RT #75527: compatibility with Carp 1.25

### DIFF
--- a/t/backcompat.t
+++ b/t/backcompat.t
@@ -8,7 +8,7 @@ eval {
     open(my $fh, '<', NO_SUCH_FILE);
 };
 
-my $old_msg = qr{Can't open\(GLOB\(0x[0-9a-f]+\), <, xyzzy_this_file_is_not_here\): .* at \(eval \d+\)(?:\[.*?\])? line \d+\s+main::__ANON__\('GLOB\(0x[0-9a-f]+\)',\s*'<',\s*'xyzzy_this_file_is_not_here'\) called at \S+ line \d+\s+eval \Q{...}\E called at \S+ line \d+};
+my $old_msg = qr{Can't open\(GLOB\(0x[0-9a-f]+\), <, xyzzy_this_file_is_not_here\): .* at \(eval \d+\)(?:\[.*?\])? line \d+\.?\s+main::__ANON__\('GLOB\(0x[0-9a-f]+\)',\s*'<',\s*'xyzzy_this_file_is_not_here'\) called at \S+ line \d+\s+eval \Q{...}\E called at \S+ line \d+};
 
 like($@,$old_msg,"Backwards compat ugly messages");
 is(ref($@),"", "Exception is a string, not an object");


### PR DESCRIPTION
Carp 1.25 now has one more dot ([RT #75527](https://rt.cpan.org/Ticket/Display.html?id=75527) in autodie queue).
This patch fixes the regexp used in `t/backcompat.t` that is checking
some Carp output.
