### PR TITLE
Fill protos tweaks

### DIFF
--- a/lib/Fatal.pm
+++ b/lib/Fatal.pm
@@ -625,6 +625,12 @@ sub unimport {
 sub fill_protos {
     my $proto = shift;
     my ($n, $isref, @out, @out1, $seen_semi) = -1;
+    if ($proto =~ m{^\s* (?: [;] \s*)? \@}x) {
+        # prototype is entirely slurp - special case that does not
+        # require any handling.
+        return ([0, '@_']);
+    }
+
     while ($proto =~ /\S/) {
         $n++;
         push(@out1,[$n,@out]) if $seen_semi;
@@ -677,7 +683,7 @@ sub _write_invocation {
 
             my $condition = "\@_ == $n";
 
-            if (@argv and $argv[-1] =~ /#_/) {
+            if (@argv and $argv[-1] =~ /[#@]_/) {
                 # This argv ends with '@' in the prototype, so it matches
                 # any number of args >= the number of expressions in the
                 # argv.


### PR DESCRIPTION
I got another branch:
1. Fatal: Optimize out calls to fill_protos
2. Fatal: special case "@" prototypes in fill_protos

Commit 1. is a minor optimization of load time for importing of cached subs.  It does put a bit of extra cost on generating the trampoline for leak calls to CORE subs.  That said I believe it overall is a win because you now pay for "fill_protos" at most twice per sub (once at import and once at the first leak) instead of once per import of the sub.

Commit 2. makes fill_protos special case prototypes consisting entirely of "@" (or ";@") and have it emit a simpler call by using @_ instead of slicing it as @_[0..$#_].
