### PR TITLE
Fatal: Reusable trampolines

### DIFF
--- a/lib/Fatal.pm
+++ b/lib/Fatal.pm
@@ -1458,7 +1458,13 @@ sub _make_leak_guard {
 
         # We are wrapping a CORE sub
 
-        # If we've cached a trampoline, then use it.
+        # If we've cached a trampoline, then use it.  Note that we use
+        # "Fatal" as package name for reusable subs because A) that
+        # allows us to trivially re-use the trampolines as well and B)
+        # because the reusable sub is compiled into "package Fatal" as
+        # well.
+
+        $pkg = 'Fatal' if exists $reusable_builtins{$call};
         my $trampoline_sub = $Trampoline_cache{$pkg}{$call};
 
         if (not $trampoline_sub) {
@@ -1466,8 +1472,6 @@ sub _make_leak_guard {
             #
             # We only generate trampolines when we need them, and
             # we can cache them by subroutine + package.
-
-            # TODO: Consider caching on reusable_builtins status as well.
 
             $trampoline_sub = _make_core_trampoline($call, $pkg, $proto);
 


### PR DESCRIPTION
When a reusable "CORE" sub is leaked, compile and cache its trampoline
under the "Fatal" package rather than the original package[1].  This
allows autodie to trivially reuse the trampoline on leaks from other
packages as well.

[1] Note that the wrapper sub is compiled into "Fatal" as well when
the "CORE" sub is reusable.

Signed-off-by: Niels Thykier niels@thykier.net
