### PR TITLE
Optimizations and refactoring for 2.20

### DIFF
--- a/lib/Fatal.pm
+++ b/lib/Fatal.pm
@@ -631,7 +631,7 @@ sub _translate_import_args {
     # We assume that $TAGS{':all'} is pre-expanded and just fill it in
     # from the beginning.
     my %tag_cache = (
-        'all' => $TAGS{':all'},
+        'all' => [map { "CORE::$_" } @{$TAGS{':all'}}],
     );
 
     # Expand a given tag (e.g. ":default") into a listref containing


### PR DESCRIPTION
I got another 5 patches, which combined cuts the "use autodie" time by another factor 4 (on top of the factor 2 improvement we got in 2.18) on the benchmark.pl case.  The major speed improvement is obtained by making autodie lazy (commit ed7c623), so consumers will now only pay for what they use.
