### PR TITLE
Add a note that autodie doesn't check print

### DIFF
--- a/lib/autodie.pm
+++ b/lib/autodie.pm
@@ -265,6 +265,10 @@ C<system> and C<exec> with:
 
 =head1 FUNCTION SPECIFIC NOTES
 
+=head2 print
+
+The autodie pragma B<<does not check calls to C<print>>>.
+
 =head2 flock
 
 It is not considered an error for C<flock> to return false if it fails


### PR DESCRIPTION
I know it's not listed as checking it, but it's easy to assume that it does since it checks other IO calls.
