### PR TITLE
t/open.t: Workarounds for Android and Blackberry 10

### DIFF
--- a/t/open.t
+++ b/t/open.t
@@ -53,7 +53,9 @@ unlike($@, qr/at \S+ line \d+\s+at \S+ line \d+/, "...but not too mentions");
 # Sniff to see if we can run 'true' on this system.  Changes we can't
 # on non-Unix systems.
 
-my @true = $^O =~ /android/
+use Config;
+my @true = ($^O =~ /android/
+            || ($Config{usecrosscompile} && $^O eq 'nto' ))
         ? ('sh', '-c', 'true $@', '--')
         : 'true';
 


### PR DESCRIPTION
Howdy!

Quick disclaimer: Android support just got into the perl core. Blackberry 10/embedded QNX NTO isn't merged yet.

That aside, the issue with both of those platforms is that 'true' and several other commands, like echo and pwd, are a shell builtins without an external binary, so three-arg open won't work; you need to either use two-arg open, which implicitly creates a subshell, or still use three-arg but instead pass something like 'sh', '-c', 'true $@', '--'

This pull request does the latter, but only for these OSs.
