### PR TITLE
Specifying raw on open does not work properly when open pragma is used with autodie

### DIFF
--- a/t/utf8_open.t
+++ b/t/utf8_open.t
@@ -9,7 +9,6 @@ use autodie;
 
 use Fcntl;
 use File::Temp;
-
 use Test::More;
 
 if( $] < '5.01000' ) {
@@ -72,6 +71,15 @@ else {
 
         my @layers = PerlIO::get_layers($fh);
         ok( (grep { $_ eq 'utf8' } @layers), "open implicit read honors open pragma" ) or diag join ", ", @layers;
+    }
+
+    # raw
+    {
+        open my $fh, ">:raw", $file;
+
+        my @layers = PerlIO::get_layers($fh);
+
+        ok( !(grep { $_ eq 'utf8' } @layers), 'open pragma is not used if raw is specified' ) or diag join ", ", @layers;
     }
 }
 


### PR DESCRIPTION
When using the open pragma with autodie, the encoding set in the open pragma is applied even when the user specifies `:raw` in their call to open. This PR is a test case, which passes when autodie is not used.

I think this is related to the fix from #12. 
