### PR TITLE
autodie: Mention that "kill" is guarded under the ":ipc"-tag

### DIFF
--- a/lib/autodie.pm
+++ b/lib/autodie.pm
@@ -210,6 +210,7 @@ The categories are currently:
                     symlink
                     unlink
                 :ipc
+                    kill
                     pipe
                     :msg
                         msgctl


### PR DESCRIPTION
Signed-off-by: Niels Thykier niels@thykier.net
