### PR TITLE
Fix weird error during global destruction

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for autodie
 
 {{$NEXT}}
 
+        * BUGFIX: Fixed an error that could occur during global destruction of
+          the form "(in cleanup) Can't use an undefined value as an ARRAY
+          reference at .../autodie/Scope/GuardStack.pm line 48 during global
+          destruction" (Dave Rolsky).
+
 2.25      2014-04-03 09:43:15EST+1100 Australia/Melbourne
 
         * DOCS: Spelling fixes in autodie::ScopeUtil

--- a/lib/autodie/Scope/GuardStack.pm
+++ b/lib/autodie/Scope/GuardStack.pm
@@ -44,7 +44,10 @@ sub push_hook {
         #  then hook 2.  hook 3 will then be destroyed, but do nothing
         #  since its "frame" was already popped and finally hook 1
         #  will be popped and take its own frame with it.
-        $self->_pop_hook while @{$self} > $size;
+        #
+        #  We need to check that $self still exists since things can get weird
+        #  during global destruction.
+        $self->_pop_hook while $self && @{$self} > $size;
     });
     push(@{$self}, [$hook, $h_key]);
     return;


### PR DESCRIPTION
(in cleanup) Can't use an undefined value as an ARRAY reference at
.../autodie/Scope/GuardStack.pm line 48 during global destruction.
