### PR TITLE
Hard coded directory separator causes test failure

### DIFF
--- a/t/system.t
+++ b/t/system.t
@@ -41,7 +41,7 @@ like($@,qr{failed to start}, "Reason for failure given");
 like($@,qr{@{[NO_SUCH_FILE]}},"Failed command given");
 
 # The error should report *this* file.  See RT #38066
-like($@,qr{at (?:t/)?system.t line \d});
+like($@,qr{at \Q$0\E line \d});
 
 eval "system { \$^X} 'perl', '-e1'";
 is($@,"","Exotic system in same package not harmed");


### PR DESCRIPTION
Instead of matching against hard-coded test file name, use `\Q$0\E`. 

Here is the error for reference:

<pre>t\system.t ....................... 1/9
#   Failed test at t\system.t line 44.
#                   '"this_file_had_so_better_not_be_here" failed to start: "The system cannot find the file specified" at (eval 22) line 12.
#  at t\system.t line 35
# '
#     doesn't match '(?^:at (?:t/)?system.t line \d)'
# Looks like you failed 1 test of 9.
t\system.t ....................... Dubious, test returned 1 (wstat 256, 0x100)</pre>
