### PR TITLE
Refactoring and execption message improvements

### DIFF
--- a/lib/autodie/exception.pm
+++ b/lib/autodie/exception.pm
@@ -320,7 +320,7 @@ sub _octalize_number {
     # Only reformat if:
     # - it looks like a number
     # - doesn't seem to be in octal form already
-    if ($number =~ /^[1-9]\d+$/) {
+    if ($number =~ /^[1-9]\d*$/) {
         $number = sprintf("0%lo", $number);
     }
 

--- a/lib/autodie/exception.pm
+++ b/lib/autodie/exception.pm
@@ -320,7 +320,7 @@ sub _octalize_number {
     # Only reformat if:
     # - it looks like a number
     # - doesn't seem to be in octal form already
-    if ($number =~ /^[^\D0]\d+$/) {
+    if ($number =~ /^[1-9]\d+$/) {
         $number = sprintf("0%lo", $number);
     }
 

--- a/lib/autodie/exception.pm
+++ b/lib/autodie/exception.pm
@@ -320,7 +320,8 @@ sub _trim_package_name {
     # a good idea for other subs?
 
     # Trim package name off dying sub for error messages
-    return $_[1] =~ s/.*:://r;
+    (my $name = $_[1]) =~ s/.*:://;
+    return $name;
 }
 
 # Returns the parameter formatted as octal number

--- a/lib/autodie/exception.pm
+++ b/lib/autodie/exception.pm
@@ -317,11 +317,9 @@ sub _beautify_arguments {
 sub _octalize_number {
     my $number = $_[1];
 
-    # Only reformat if:
-    # - it looks like a number
-    # - doesn't seem to be in octal form already
-    if ($number =~ /^[1-9]\d*$/) {
-        $number = sprintf("0%lo", $number);
+    # Only reformat if it looks like a whole number
+    if ($number =~ /^\d+$/) {
+        $number = sprintf("%#lo", $number);
     }
 
     return $number;

--- a/lib/autodie/exception.pm
+++ b/lib/autodie/exception.pm
@@ -313,6 +313,20 @@ sub _beautify_arguments {
     return @_;
 }
 
+# Returns the parameter formatted as octal number
+sub _octalize_number {
+    my $number = $_[1];
+
+    # Only reformat if:
+    # - it looks like a number
+    # - doesn't seem to be in octal form already
+    if ($number =~ /^[^\D0]\d+$/) {
+        $number = sprintf("0%lo", $number);
+    }
+
+    return $number;
+}
+
 # TODO: Our tests only check LOCK_EX | LOCK_NB is properly
 # formatted.  Try other combinations and ensure they work
 # correctly.
@@ -375,13 +389,7 @@ sub _format_chmod {
     my $mode   = shift @args;
     local $!   = $this->errno;
 
-    # If we have a mode, then display it in octal, not decimal.
-    # We don't do this if it already looks octalish, or doesn't
-    # look like a number.
-
-    if ($mode =~ /^[^\D0]\d+$/) {
-        $mode = sprintf("0%lo", $mode);
-    }
+    $mode = $this->_octalize_number($mode);
 
     @args = $this->_beautify_arguments(@args);
 
@@ -402,13 +410,7 @@ sub _format_mkdir {
     my $mask = $args[1];
     local $! = $this->errno;
 
-    # If we have a mask, then display it in octal, not decimal.
-    # We don't do this if it already looks octalish, or doesn't
-    # look like a number.
-
-    if ($mask =~ /^[^\D0]\d+$/) {
-        $mask = sprintf("0%lo", $mask);
-    }
+    $mask = $this->_octalize_number($mask);
 
     return "Can't mkdir('$file', $mask): '$!'";
 }
@@ -427,13 +429,7 @@ sub _format_dbmopen {
     my $mode = $args[-1];
     my $file = $args[-2];
 
-    # If we have a mask, then display it in octal, not decimal.
-    # We don't do this if it already looks octalish, or doesn't
-    # look like a number.
-
-    if ($mode =~ /^[^\D0]\d+$/) {
-        $mode = sprintf("0%lo", $mode);
-    };
+    $mode = $this->_octalize_number($mode);
 
     local $! = $this->errno;
 

--- a/lib/autodie/exception.pm
+++ b/lib/autodie/exception.pm
@@ -319,7 +319,7 @@ sub _octalize_number {
 
     # Only reformat if it looks like a whole number
     if ($number =~ /^\d+$/) {
-        $number = sprintf("%#lo", $number);
+        $number = sprintf("%#04lo", $number);
     }
 
     return $number;

--- a/lib/autodie/exception.pm
+++ b/lib/autodie/exception.pm
@@ -292,6 +292,7 @@ my %formatter_of = (
     'CORE::read'     => \&_format_readwrite,
     'CORE::sysread'  => \&_format_readwrite,
     'CORE::syswrite' => \&_format_readwrite,
+    'CORE::chmod'    => \&_format_chmod,
 );
 
 # TODO: Our tests only check LOCK_EX | LOCK_NB is properly
@@ -346,6 +347,25 @@ sub _format_flock {
 
     return "Can't $lock_unlock filehandle$cooked_filehandle $mode_type: $!";
 
+}
+
+# Default formatter for CORE::chmod
+sub _format_chmod {
+    my ($this) = @_;
+    my @args   = @{$this->args};
+
+    my $mode   = shift @args;
+    local $!   = $this->errno;
+
+    # If we have a mode, then display it in octal, not decimal.
+    # We don't do this if it already looks octalish, or doesn't
+    # look like a number.
+
+    if ($mode =~ /^[^\D0]\d+$/) {
+        $mode = sprintf("0%lo", $mode);
+    }
+
+    return "Can't chmod($mode, ". join(q{, }, @args) ."): '$!'";
 }
 
 # Default formatter for CORE::dbmopen

--- a/lib/autodie/exception.pm
+++ b/lib/autodie/exception.pm
@@ -313,6 +313,16 @@ sub _beautify_arguments {
     return @_;
 }
 
+sub _trim_package_name {
+    # Info: The following is done since 05/2008 (which is before v1.10)
+
+    # TODO: This is probably a good idea for CORE, is it
+    # a good idea for other subs?
+
+    # Trim package name off dying sub for error messages
+    return $_[1] =~ s/.*:://r;
+}
+
 # Returns the parameter formatted as octal number
 sub _octalize_number {
     my $number = $_[1];
@@ -458,11 +468,8 @@ sub _format_close {
 # may contain binary data.
 sub _format_readwrite {
     my ($this) = @_;
-    my $call = $this->function;
+    my $call = $this->_trim_package_name($this->function);
     local $! = $this->errno;
-
-    # Trim package name off dying sub for error messages.
-    $call =~ s/.*:://;
 
     # These subs receive the following arguments (in order):
     #
@@ -678,15 +685,9 @@ messages are formatted.
 sub format_default {
     my ($this) = @_;
 
-    my $call        =  $this->function;
+    my $call   =  $this->_trim_package_name($this->function);
 
     local $! = $this->errno;
-
-    # TODO: This is probably a good idea for CORE, is it
-    # a good idea for other subs?
-
-    # Trim package name off dying sub for error messages.
-    $call =~ s/.*:://;
 
     my @args = @{ $this->args() };
     @args = $this->_beautify_arguments(@args);

--- a/t/chmod.t
+++ b/t/chmod.t
@@ -1,13 +1,15 @@
 #!/usr/bin/perl -w
 use strict;
-use Test::More tests => 4;
+use Test::More tests => 5;
 use constant NO_SUCH_FILE => "this_file_had_better_not_exist";
+use constant ERROR_REGEXP => qr{Can't chmod\(0755, ${\(NO_SUCH_FILE)}\):};
 use autodie;
 
 # This tests RT #50423, Debian #550462
 
 eval { chmod(0755, NO_SUCH_FILE); };
 isa_ok($@, 'autodie::exception', 'exception thrown for chmod');
+like($@, ERROR_REGEXP, "Message should include numeric mode in octal form");
 
 eval { chmod(0755, $0); };
 ok(! $@, "We can chmod ourselves just fine.");

--- a/t/chmod.t
+++ b/t/chmod.t
@@ -3,7 +3,7 @@ use strict;
 use Test::More tests => 7;
 use constant NO_SUCH_FILE => "this_file_had_better_not_exist";
 use constant ERROR_REGEXP => qr{Can't chmod\(0755, '${\(NO_SUCH_FILE)}'\):};
-use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't chmod\(010, '${\(NO_SUCH_FILE)}'\):};
+use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't chmod\(0010, '${\(NO_SUCH_FILE)}'\):};
 use autodie;
 
 # This tests RT #50423, Debian #550462

--- a/t/chmod.t
+++ b/t/chmod.t
@@ -2,7 +2,7 @@
 use strict;
 use Test::More tests => 5;
 use constant NO_SUCH_FILE => "this_file_had_better_not_exist";
-use constant ERROR_REGEXP => qr{Can't chmod\(0755, ${\(NO_SUCH_FILE)}\):};
+use constant ERROR_REGEXP => qr{Can't chmod\(0755, '${\(NO_SUCH_FILE)}'\):};
 use autodie;
 
 # This tests RT #50423, Debian #550462

--- a/t/chmod.t
+++ b/t/chmod.t
@@ -1,8 +1,9 @@
 #!/usr/bin/perl -w
 use strict;
-use Test::More tests => 5;
+use Test::More tests => 7;
 use constant NO_SUCH_FILE => "this_file_had_better_not_exist";
 use constant ERROR_REGEXP => qr{Can't chmod\(0755, '${\(NO_SUCH_FILE)}'\):};
+use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't chmod\(010, '${\(NO_SUCH_FILE)}'\):};
 use autodie;
 
 # This tests RT #50423, Debian #550462
@@ -10,6 +11,10 @@ use autodie;
 eval { chmod(0755, NO_SUCH_FILE); };
 isa_ok($@, 'autodie::exception', 'exception thrown for chmod');
 like($@, ERROR_REGEXP, "Message should include numeric mode in octal form");
+
+eval { chmod(8, NO_SUCH_FILE); };
+isa_ok($@, 'autodie::exception', 'exception thrown for chmod');
+like($@, SINGLE_DIGIT_ERROR_REGEXP, "Message should include numeric mode in octal form");
 
 eval { chmod(0755, $0); };
 ok(! $@, "We can chmod ourselves just fine.");

--- a/t/dbmopen.t
+++ b/t/dbmopen.t
@@ -1,8 +1,9 @@
 #!/usr/bin/perl -w
 use strict;
-use Test::More qw(no_plan);
+use Test::More tests => 9;
 
 use constant ERROR_REGEXP => qr{Can't dbmopen\(%hash, 'foo/bar/baz', 0666\):};
+use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't dbmopen\(%hash, 'foo/bar/baz', 010\):};
 
 my $return = "default";
 
@@ -23,6 +24,17 @@ ok($@, "autodie allows dbmopen to throw errors.");
 isa_ok($@, "autodie::exception", "... errors are of the correct type");
 
 like($@, ERROR_REGEXP, "Message should include number in octal, not decimal");
+
+eval {
+    use autodie;
+
+    dbmopen(my %foo, "foo/bar/baz", 8);
+};
+
+ok($@, "autodie allows dbmopen to throw errors.");
+isa_ok($@, "autodie::exception", "... errors are of the correct type");
+
+like($@, SINGLE_DIGIT_ERROR_REGEXP, "Message should include number in octal, not decimal");
 
 eval {
     use autodie;

--- a/t/dbmopen.t
+++ b/t/dbmopen.t
@@ -3,7 +3,7 @@ use strict;
 use Test::More tests => 9;
 
 use constant ERROR_REGEXP => qr{Can't dbmopen\(%hash, 'foo/bar/baz', 0666\):};
-use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't dbmopen\(%hash, 'foo/bar/baz', 010\):};
+use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't dbmopen\(%hash, 'foo/bar/baz', 0010\):};
 
 my $return = "default";
 

--- a/t/mkdir.t
+++ b/t/mkdir.t
@@ -3,6 +3,7 @@ use strict;
 use Test::More;
 use FindBin qw($Bin);
 use constant TMPDIR => "$Bin/mkdir_test_delete_me";
+use constant ERROR_REGEXP => qr{Can't mkdir\('${\(TMPDIR)}', 0777\):};
 
 # Delete our directory if it's there
 rmdir TMPDIR;
@@ -25,7 +26,7 @@ if(-d TMPDIR) { plan skip_all => "Failed to delete test directory"; }
 # Try to delete second time
 if(rmdir TMPDIR) { plan skip_all => "Able to rmdir directory twice"; }
 
-plan tests => 12;
+plan tests => 13;
 
 # Create a directory (this should succeed)
 eval {
@@ -40,12 +41,13 @@ ok(-d TMPDIR, "Successfully created test directory");
 eval {
 	use autodie;
 
-	mkdir TMPDIR;
+	mkdir TMPDIR, 0777;
 };
 ok($@, "Re-creating directory causes failure.");
 isa_ok($@, "autodie::exception", "... errors are of the correct type");
 ok($@->matches("mkdir"), "... it's also a mkdir object");
 ok($@->matches(":filesys"), "... and a filesys object");
+like($@, ERROR_REGEXP, "Message should include numeric mask in octal form");
 
 # Try to delete directory (this should succeed)
 eval {

--- a/t/mkdir.t
+++ b/t/mkdir.t
@@ -4,6 +4,7 @@ use Test::More;
 use FindBin qw($Bin);
 use constant TMPDIR => "$Bin/mkdir_test_delete_me";
 use constant ERROR_REGEXP => qr{Can't mkdir\('${\(TMPDIR)}', 0777\):};
+use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't mkdir\('${\(TMPDIR)}', 010\):};
 
 # Delete our directory if it's there
 rmdir TMPDIR;
@@ -26,7 +27,7 @@ if(-d TMPDIR) { plan skip_all => "Failed to delete test directory"; }
 # Try to delete second time
 if(rmdir TMPDIR) { plan skip_all => "Able to rmdir directory twice"; }
 
-plan tests => 13;
+plan tests => 18;
 
 # Create a directory (this should succeed)
 eval {
@@ -48,6 +49,17 @@ isa_ok($@, "autodie::exception", "... errors are of the correct type");
 ok($@->matches("mkdir"), "... it's also a mkdir object");
 ok($@->matches(":filesys"), "... and a filesys object");
 like($@, ERROR_REGEXP, "Message should include numeric mask in octal form");
+
+eval {
+        use autodie;
+
+        mkdir TMPDIR, 8;
+};
+ok($@, "Re-creating directory causes failure.");
+isa_ok($@, "autodie::exception", "... errors are of the correct type");
+ok($@->matches("mkdir"), "... it's also a mkdir object");
+ok($@->matches(":filesys"), "... and a filesys object");
+like($@, SINGLE_DIGIT_ERROR_REGEXP, "Message should include numeric mask in octal form");
 
 # Try to delete directory (this should succeed)
 eval {

--- a/t/mkdir.t
+++ b/t/mkdir.t
@@ -4,7 +4,7 @@ use Test::More;
 use FindBin qw($Bin);
 use constant TMPDIR => "$Bin/mkdir_test_delete_me";
 use constant ERROR_REGEXP => qr{Can't mkdir\('${\(TMPDIR)}', 0777\):};
-use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't mkdir\('${\(TMPDIR)}', 010\):};
+use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't mkdir\('${\(TMPDIR)}', 0010\):};
 
 # Delete our directory if it's there
 rmdir TMPDIR;


### PR DESCRIPTION
This pull request builds upon pull #65 and

* fixes a bug in the octal formatting of permission mask parameters
* refactors a few duplicated code pieces into helper functions
* improves the octal display of permission masks

This pull-request is part of the [2015 CPAN PR Challenge](http://blogs.perl.org/users/neilb/2014/12/take-the-2015-cpan-pull-request-challenge.html)