### PR TITLE
t/import-into.t: enforce the minimum version of Import::Into

### DIFF
--- a/t/import-into.t
+++ b/t/import-into.t
@@ -6,8 +6,8 @@ use warnings;
 use Test::More;
 
 BEGIN {
-    eval 'use Import::Into';
-    plan skip_all => 'Test needs Import::Into' if $@;
+    eval 'use Import::Into 1.002004';
+    plan skip_all => 'Test needs Import::Into >= 1.002004' if $@;
 }
 
 use FindBin;


### PR DESCRIPTION
This is a followup to [RT#101377](https://rt.cpan.org/Ticket/Display.html?id=101377).
Since release 2.27 we specify the mimimum version of Import::Into in META.{yml,json} as test/recommends (see 46b3dcc65a83bcf340f12a676eb0192e54dff95d). But as this is just a `recommends` dependency, the CPAN client is free to ignore it and not upgrade `Import::Into`. If `Import::Into` is too old, we want to skip the test in the same way as if `Import::Into` is not here at all. So we now check the $VERSION.