### PR TITLE
install into perl rather than site for older perls (RT#85801)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for autodie
 
 {{$NEXT}}
+        * install into 'perl' rather than 'site' for older perls (RT#85801)
 
 2.28      2015-06-22 16:20:35+10:00 Australia/Melbourne
 

--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,10 @@ repository.type = git
 
 bugtracker.web  = http://rt.cpan.org/NoAuth/Bugs.html?Dist=autodie
 
+[DualLife]
+; autodie.pm entered in 5.010001, but we need to handle Fatal.pm as well
+entered_core = 5.00307
+
 [Test::Perl::Critic]
 [PodCoverageTests]
 [PodSyntaxTests]


### PR DESCRIPTION
Fatal.pm entered core long before autodie.pm did, and both of them need to be
overwritten by the upgraded version.