### PR TITLE
Fix a scoping issue with "no autodie" and the "system" sub

### DIFF
--- a/lib/Fatal.pm
+++ b/lib/Fatal.pm
@@ -563,6 +563,8 @@ sub unimport {
 
     for my $symbol ($class->_translate_import_args(@unimport_these)) {
 
+        next if !exists $::{$symbol};
+
         my $sub = $symbol;
         $sub = "${pkg}::$sub" unless $sub =~ /::/;
 

--- a/t/no-all.t
+++ b/t/no-all.t
@@ -1,0 +1,17 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+use Test::More tests => 1;
+use autodie qw(:all);
+
+use_system();
+ok("system() works with a lexical 'no autodie' block (github issue #69");
+
+sub break_system {
+    no autodie;
+}
+
+sub use_system {
+    system($^X, '-e' , 1);
+}

--- a/t/no-default.t
+++ b/t/no-default.t
@@ -1,0 +1,17 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+use Test::More tests => 1;
+use autodie;
+
+use_system();
+ok("system() works with a lexical 'no autodie' block (github issue #69");
+
+sub break_system {
+    no autodie;
+}
+
+sub use_system {
+    system($^X, '-e' , 1);
+}


### PR DESCRIPTION
Skip uninstalling subs that we never installed. This makes
sure we don't try to reinstall nonexisting subs later when
exiting the 'no autodie' scope.

Bug: https://github.com/pjf/autodie/issues/69
Bug-Debian: https://bugs.debian.org/798096