### PR TITLE
Escapes build dir path in mkdir.t to avoid failures if path has metachars

### DIFF
--- a/t/mkdir.t
+++ b/t/mkdir.t
@@ -3,8 +3,8 @@ use strict;
 use Test::More;
 use FindBin qw($Bin);
 use constant TMPDIR => "$Bin/mkdir_test_delete_me";
-use constant ERROR_REGEXP => qr{Can't mkdir\('${\(TMPDIR)}', 0777\):};
-use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't mkdir\('${\(TMPDIR)}', 0010\):};
+use constant ERROR_REGEXP => qr{Can't mkdir\('\Q${\(TMPDIR)}\E', 0777\):};
+use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't mkdir\('\Q${\(TMPDIR)}\E', 0010\):};
 
 # Delete our directory if it's there
 rmdir TMPDIR;


### PR DESCRIPTION
This PR applies the patch submitted with Dave Mitchell's bug report
(RT#105344). Per Dave's bug report:

    autodie/t/mkdir.t: escape build dir path

    This test file creates a regex which includes the path of the build
    directory. If that path includes regex metachars (e.g. blead_g++_quick)
    then the test fails. Easily fixed with \Q...\E.

I'm submitting it as a github PR to let travis.ci do its thing and make
it as easy as possibly for the maintainers to apply the patch. This is
part of Feb. 2016's PRC.