### PR TITLE
autodie: fix POD misformatting

### DIFF
--- a/lib/autodie.pm
+++ b/lib/autodie.pm
@@ -268,7 +268,7 @@ C<system> and C<exec> with:
 
 =head2 print
 
-The autodie pragma B<<does not check calls to C<print>>>.
+The autodie pragma B<does not check calls to C<print>Z<>>.
 
 =head2 flock
 


### PR DESCRIPTION
perldoc (at least 5.22's version) doesn't seem to understand when closing angle brackets from multiple formatting codes are concatenated, resulting in a misformatting.  Use a Z<> code to split them up so that the text renders correctly.