### PR TITLE
Ackrc: Ignore build directories

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -1,0 +1,1 @@
+--ignore-dir=.build


### PR DESCRIPTION
This adds a simple `.ackrc` file which means that `ack TODO` and similar commands won't search through build directories.

Ack is a [better grep](http://beyondgrep.com/).