### PR TITLE
fix && logic in CORE::kill changes

### DIFF
--- a/lib/Fatal.pm
+++ b/lib/Fatal.pm
@@ -1039,8 +1039,8 @@ sub _one_invocation {
             my \$retval = $call(@argv);
             my \$sigzero = looks_like_number( \$signal ) && \$signal == 0;
 
-            if (    (   \$sigzero and \$context eq 'void' )
-                 or ( ! \$sigzero and \$retval != \$num_things ) ) {
+            if (    (   \$sigzero && \$context eq 'void' )
+                 or ( ! \$sigzero && \$retval != \$num_things ) ) {
 
                 $die;
             }

--- a/lib/Fatal.pm
+++ b/lib/Fatal.pm
@@ -1037,7 +1037,7 @@ sub _one_invocation {
             my \$context = ! defined wantarray() ? 'void' : 'scalar';
             my \$signal = \$_[0];
             my \$retval = $call(@argv);
-            my \$sigzero = looks_like_number( \$signal ) and \$signal == 0;
+            my \$sigzero = looks_like_number( \$signal ) && \$signal == 0;
 
             if (    (   \$sigzero and \$context eq 'void' )
                  or ( ! \$sigzero and \$retval != \$num_things ) ) {


### PR DESCRIPTION
Saw there was a "useless use of numeric eq (==) in void context" warning related to using kill 0, $pid to check if a pid is alive.

The $sigzero statement was using the low-precedence "and" rather than "&&"

