### PR TITLE
prereq cleanup

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -40,12 +40,6 @@ entered_core = 5.00307
 ; Skip Klingon testing pre-reqs. They're included in the test dir.
 skip = ^pujHa
 
-; Skip optional testing modules
-skip = ^(?:BSD::Resource|Test::Kwalitee|Test::Perl::Critic|Import::Into)$
-
-; Some modules are nice to have, but not required.
-skip = ^(?:IPC::System::Simple|Sub::Identify)$
-
 ; We'll specify our own minimum version of Perl, thanks!
 skip = ^perl$
 
@@ -56,18 +50,21 @@ perl = 5.008004
 
 [Prereqs / TestRecommends]
 perl = 5.010
-BSD::Resource = 0
-Test::Kwalitee = 0
-Test::Perl::Critic = 0
 Import::Into = 1.002004
-
-; release-pod-coverage.t likes this
-Pod::Coverage::TrustPod = 0
 
 [Prereqs / RuntimeRecommends]
 perl = 5.010
 IPC::System::Simple = 0.12
-Sub::Identify = 0
+
+[Prereqs::Soften]
+copy_to = develop.requires
+to_relationship = recommends
+; Some modules are nice to have, but not required.
+module = IPC::System::Simple
+module = Sub::Identify
+; optional testing modules
+module = BSD::Resource
+module = Import::Into
 
 [OurPkgVersion]
 [CPANFile]

--- a/dist.ini
+++ b/dist.ini
@@ -30,8 +30,6 @@ entered_core = 5.00307
 [MetaYAML]
 [License]
 [ExtraTests]
-[ExecDir]
-[ShareDir]
 [MakeMaker]
 [Manifest]
 [TestRelease]

--- a/dist.ini
+++ b/dist.ini
@@ -29,7 +29,7 @@ entered_core = 5.00307
 [ManifestSkip]
 [MetaYAML]
 [License]
-[ExtraTests]
+[RunExtraTests]
 [MakeMaker]
 [Manifest]
 [TestRelease]


### PR DESCRIPTION
I noticed a few prereqs were showing up as test recommendations that shouldn't be (they are only run during author/release tests); this is a minor cleanup of dist.ini to keep author tests in xt (otherwise, an extra process is used for each test at user install time), and to ensure that unwanted prereqs never become required.

A diff of the resulting build shows nothing untoward (and you get a few extra prereqs added in the 'develop' section automatically which can help contributors).