### PR TITLE
Fix extra space in autodie::Scope::GuardStack NAME

### DIFF
--- a/lib/autodie/Scope/GuardStack.pm
+++ b/lib/autodie/Scope/GuardStack.pm
@@ -78,7 +78,7 @@ __END__
 
 =head1 NAME
 
-autodie::Scope::GuardStack -  Hook stack for managing scopes via %^H
+autodie::Scope::GuardStack - Hook stack for managing scopes via %^H
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
This extra space was causing a misformatting in the generated perlmodlib. See https://rt.perl.org/Ticket/Display.html?id=133683