### PR TITLE
chmod/chown/utime: don't modify ourselves

### DIFF
--- a/t/chmod.t
+++ b/t/chmod.t
@@ -4,6 +4,7 @@ use Test::More tests => 7;
 use constant NO_SUCH_FILE => "this_file_had_better_not_exist";
 use constant ERROR_REGEXP => qr{Can't chmod\(0755, '${\(NO_SUCH_FILE)}'\):};
 use constant SINGLE_DIGIT_ERROR_REGEXP => qr{Can't chmod\(0010, '${\(NO_SUCH_FILE)}'\):};
+use File::Temp qw(tempfile);
 use autodie;
 
 # This tests RT #50423, Debian #550462
@@ -16,9 +17,11 @@ eval { chmod(8, NO_SUCH_FILE); };
 isa_ok($@, 'autodie::exception', 'exception thrown for chmod');
 like($@, SINGLE_DIGIT_ERROR_REGEXP, "Message should include numeric mode in octal form");
 
-eval { chmod(0755, $0); };
-ok(! $@, "We can chmod ourselves just fine.");
+my ($fh, $filename) = tempfile;
 
-eval { chmod(0755, $0, NO_SUCH_FILE) };
+eval { chmod(0755, $filename); };
+ok(! $@, "We can chmod a file we own just fine.");
+
+eval { chmod(0755, $filename, NO_SUCH_FILE) };
 isa_ok($@, 'autodie::exception', 'chmod exception on any file failure.');
 is($@->return,1,"Confirm autodie on a 'true' chown failure.");

--- a/t/chown.t
+++ b/t/chown.t
@@ -3,6 +3,7 @@ use strict;
 use Test::More;
 use constant NO_SUCH_FILE => "this_file_had_better_not_exist";
 use autodie;
+use File::Temp qw(tempfile);
 
 if ($^O eq 'MSWin32') {
     plan skip_all => 'chown() seems to always succeed on Windows';
@@ -20,9 +21,11 @@ isa_ok($@, 'autodie::exception', 'exception thrown for chown');
 # should die if the return value is not equal to the number of arguments
 # minus two.
 
-eval { chown($<, -1, $0); };
-ok(! $@, "Can chown ourselves just fine.");
+my ($fh, $filename) = tempfile;
 
-eval { chown($<, -1, $0, NO_SUCH_FILE); };
+eval { chown($<, -1, $filename); };
+ok(! $@, "Can chown a file we own just fine.");
+
+eval { chown($<, -1, $filename, NO_SUCH_FILE); };
 isa_ok($@, 'autodie::exception', "Exception if ANY file changemode fails");
 is($@->return, 1, "Confirm we're dying on a 'true' chown failure.");

--- a/t/touch_me
+++ b/t/touch_me
@@ -1,2 +1,0 @@
-For testing utime.
-Contents of this file are irrelevant.

--- a/t/utime.t
+++ b/t/utime.t
@@ -4,21 +4,19 @@ use Test::More tests => 4;
 use constant NO_SUCH_FILE => "this_file_had_better_not_exist";
 use FindBin qw($Bin);
 use File::Spec;
-use constant TOUCH_ME     => File::Spec->catfile($Bin, 'touch_me');
 use autodie;
+use File::Temp qw(tempfile);
+
+my ($fh, $filename) = tempfile;
 
 eval { utime(undef, undef, NO_SUCH_FILE); };
 isa_ok($@, 'autodie::exception', 'exception thrown for utime');
 
-my($atime, $mtime) = (stat TOUCH_ME)[8, 9];
+my($atime, $mtime) = (stat $filename)[8, 9];
 
-eval { utime(undef, undef, TOUCH_ME); };
+eval { utime(undef, undef, $filename); };
 ok(! $@, "We can utime a file just fine.") or diag $@;
 
-eval { utime(undef, undef, NO_SUCH_FILE, TOUCH_ME); };
+eval { utime(undef, undef, NO_SUCH_FILE, $filename); };
 isa_ok($@, 'autodie::exception', 'utime exception on single failure.');
 is($@->return, 1, "utime fails correctly on a 'true' failure.");
-
-# Reset timestamps so that Git doesn't think the file has changed when
-# running the test in the core perl distribution.
-utime($atime, $mtime, TOUCH_ME);


### PR DESCRIPTION
chmod/chown/utime: don't modify ourselves
    
This would cause test failures when integrated into the perl tree,
if the perl tree wasn't writable:
```    
t/../cpan/autodie/t/chmod ......................... #   Failed test 'We can chmod ourselves just fine.'
#   at t/chmod.t line 20.
#   Failed test 'Confirm autodie on a 'true' chown failure.'
#   at t/chmod.t line 24.
#          got: '0'
#     expected: '1'
# Looks like you failed 2 tests of 7.
FAILED at test 5
t/../cpan/autodie/t/chown ......................... #   Failed test 'Can chown ourselves just fine.'
#   at t/chown.t line 24.
#   Failed test 'Confirm we're dying on a 'true' chown failure.'
#   at t/chown.t line 28.
#          got: '0'
#     expected: '1'
# Looks like you failed 2 tests of 4.
FAILED at test 2
t/../cpan/autodie/t/utime ......................... #   Failed test 'We can utime a file just fine.'
#   at t/utime.t line 16.
# Can't utime(undef, undef, '/home/tony/dev/perl/git/symlink/cpan/autodie/t/touch_me'): Permission denied at t/utime.t line 15
#   Failed test 'utime fails correctly on a 'true' failure.'
#   at t/utime.t line 20.
#          got: '0'
#     expected: '1'
Can't utime('1689212012', '1689211787', '/home/tony/dev/perl/git/symlink/cpan/autodie/t/touch_me'): Operation not permitted at t/utime.t line 24
# Looks like your test exited with 1 just after 4.
FAILED at test 2
```
Originally reported to perl as Perl/perl5#17968, then later again
as Perl/perl5#21233

Fixes #107
