### PR TITLE
Don't try to utime an open file on VMS

### DIFF
--- a/t/utime.t
+++ b/t/utime.t
@@ -8,6 +8,7 @@ use autodie;
 use File::Temp qw(tempfile);
 
 my ($fh, $filename) = tempfile;
+close $fh; # may not be able to utime an open file
 
 eval { utime(undef, undef, NO_SUCH_FILE); };
 isa_ok($@, 'autodie::exception', 'exception thrown for utime');


### PR DESCRIPTION
6407f65a60bda8 changed to using File::Temp to create the temp file for this test, which implicitly opens it for exclusive access and prevents the ability to call utime on it.